### PR TITLE
add DeadEnd type to exposed types as per doc example type declarations

### DIFF
--- a/src/XmlParser.elm
+++ b/src/XmlParser.elm
@@ -2,6 +2,7 @@ module XmlParser exposing
     ( Xml, ProcessingInstruction, DocType, DocTypeDefinition(..), Node(..), Attribute
     , parse
     , format
+    , DeadEnd
     )
 
 {-| The XML Parser.


### PR DESCRIPTION
Currently I have to make Parser a direct dep and use Parser.Advanced to access this for the parser Result
But you have a nice wrapper for it in XmlParser but it's not exposed