### PR TITLE
Fix travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,5 +4,4 @@ node_js:
 before_script:
   - npm install -g elm
   - npm install -g elm-test
-  - elm-package install -y
 script: elm-test --seed 673747140

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: node_js
 node_js:
-  - "6"
+  - 7
 before_script:
   - npm install -g elm
   - npm install -g elm-test


### PR DESCRIPTION
The Travis CI build was failing due to an old `node` version and and old `elm-package` install command.